### PR TITLE
Support java6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: java
+jdk:
+    - openjdk6
+    - openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/spotify/crtauth/CrtAuthServer.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthServer.java
@@ -38,11 +38,8 @@ import com.spotify.crtauth.utils.PublicKeys;
 import com.spotify.crtauth.utils.RealTimeSupplier;
 import com.spotify.crtauth.utils.TimeSupplier;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.Signature;
-import java.security.SignatureException;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Arrays;
 import java.util.Random;
@@ -190,7 +187,7 @@ public class CrtAuthServer {
       throw new RuntimeException(e);
     }
     VerifiableMessage<Challenge> verifiableChallenge =
-        new VerifiableMessage.Builder<>(Challenge.class)
+        new VerifiableMessage.Builder<Challenge>(Challenge.class)
             .setDigest(digest)
             .setPayload(challenge)
             .build();
@@ -228,10 +225,7 @@ public class CrtAuthServer {
       signature.initVerify(publicKey);
       signature.update(response.getVerifiableChallenge().getPayload().serialize());
       signatureVerified = signature.verify(response.getSignature());
-    } catch (NoSuchAlgorithmException |
-        InvalidKeyException |
-        SignatureException |
-        SerializationException e) {
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
     if (!signatureVerified) {
@@ -254,7 +248,7 @@ public class CrtAuthServer {
     } catch (SerializationException e) {
       throw new RuntimeException(e);
     }
-    VerifiableMessage<Token> verifiableToken = new VerifiableMessage.Builder<>(Token.class)
+    VerifiableMessage<Token> verifiableToken = new VerifiableMessage.Builder<Token>(Token.class)
         .setDigest(digestAlgorithm.getDigest(serializedToken))
         .setPayload(token)
         .build();

--- a/src/main/java/com/spotify/crtauth/keyprovider/FileKeyProvider.java
+++ b/src/main/java/com/spotify/crtauth/keyprovider/FileKeyProvider.java
@@ -21,18 +21,15 @@
 
 package com.spotify.crtauth.keyprovider;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import com.spotify.crtauth.exceptions.KeyNotFoundException;
 import com.spotify.crtauth.utils.TraditionalKeyParser;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
-import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -69,12 +66,12 @@ public class FileKeyProvider implements KeyProvider {
     }
     File keyFile = new File(keyRootDir, filename);
     try {
-      byte[] keyBytes = Files.readAllBytes(keyFile.toPath());
-      String keyString = new String(keyBytes, StandardCharsets.US_ASCII);
+      byte[] keyBytes = Files.toByteArray(keyFile);
+      String keyString = new String(keyBytes, Charsets.US_ASCII);
       RSAPublicKeySpec publicKeySpec = TraditionalKeyParser.parsePemPublicKey(keyString);
       RSAPublicKey publicKey = (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
       return publicKey;
-    } catch (IOException | InvalidKeyException | InvalidKeySpecException e) {
+    } catch (Exception e) {
       throw new KeyNotFoundException(e);
     }
   }

--- a/src/main/java/com/spotify/crtauth/keyprovider/InMemoryKeyProvider.java
+++ b/src/main/java/com/spotify/crtauth/keyprovider/InMemoryKeyProvider.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class InMemoryKeyProvider implements KeyProvider {
-  private final Map<String, RSAPublicKey> keys = new HashMap<>();
+  private final Map<String, RSAPublicKey> keys = new HashMap<String, RSAPublicKey>();
 
   public void putKey(String username, RSAPublicKey key) {
     keys.put(username, key);

--- a/src/main/java/com/spotify/crtauth/protocol/VerifiableMessage.java
+++ b/src/main/java/com/spotify/crtauth/protocol/VerifiableMessage.java
@@ -146,7 +146,7 @@ public class VerifiableMessage<T extends XdrSerializable> implements XdrSerializ
   private T buildNestedInstance() throws DeserializationException {
     try {
       return payloadClass.getConstructor().newInstance();
-    } catch (ReflectiveOperationException e) {
+    } catch (Exception e) {
       throw new DeserializationException("failed to build nested instance", e);
     }
   }

--- a/src/main/java/com/spotify/crtauth/signer/AgentSigner.java
+++ b/src/main/java/com/spotify/crtauth/signer/AgentSigner.java
@@ -61,7 +61,7 @@ public class AgentSigner implements Signer {
     PublicKey publicKey = null;
     try {
       publicKey = getKeyFromFingerprint(challenge.getFigerprint());
-    } catch (IOException | NoSuchAlgorithmException exception) {
+    } catch (Exception exception) {
       throw new SignerException();
     }
     if (publicKey == null) {
@@ -70,7 +70,7 @@ public class AgentSigner implements Signer {
     byte[] signed;
     try {
       signed = sshAgent.sign(publicKey, challenge.serialize());
-    } catch (IOException | SerializationException e) {
+    } catch (Exception e) {
       throw new SignerException();
     }
     return signed;

--- a/src/main/java/com/spotify/crtauth/utils/TraditionalKeyParser.java
+++ b/src/main/java/com/spotify/crtauth/utils/TraditionalKeyParser.java
@@ -21,6 +21,7 @@
 
 package com.spotify.crtauth.utils;
 
+import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.UnsignedBytes;
 import com.spotify.crtauth.exceptions.InvalidInputException;
@@ -28,7 +29,6 @@ import com.spotify.crtauth.exceptions.InvalidInputException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;
@@ -64,7 +64,7 @@ public class TraditionalKeyParser {
     if (typeBytes == null || expBytes == null || modBytes == null) {
       throw new InvalidKeyException();
     }
-    String type = new String(typeBytes, StandardCharsets.US_ASCII);
+    String type = new String(typeBytes, Charsets.US_ASCII);
     if (!type.equals(PUBLIC_KEY_TYPE)) {
       throw new InvalidKeyException();
     }
@@ -101,7 +101,7 @@ public class TraditionalKeyParser {
    */
   private static List<byte[]> parsePrivateKeyASN1(ByteBuffer byteBuffer)
       throws InvalidInputException {
-    final List<byte[]> collection = new ArrayList<>();
+    final List<byte[]> collection = new ArrayList<byte[]>();
     while (byteBuffer.hasRemaining()) {
       byte type = byteBuffer.get();
       int length = UnsignedBytes.toInt(byteBuffer.get());

--- a/src/main/java/com/spotify/crtauth/xdr/Xdr.java
+++ b/src/main/java/com/spotify/crtauth/xdr/Xdr.java
@@ -21,20 +21,18 @@
 
 package com.spotify.crtauth.xdr;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-
-import java.io.IOException;
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-
+import com.google.common.base.Charsets;
 import com.spotify.crtauth.exceptions.DataOutOfBoundException;
 import com.spotify.crtauth.exceptions.IllegalAsciiString;
 import com.spotify.crtauth.exceptions.IllegalLengthException;
 import com.spotify.crtauth.exceptions.XdrException;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * This class implements XDR encoding for a subset of the data types defined in RFC-4506. This
@@ -99,7 +97,7 @@ public class Xdr implements XdrEncoder, XdrDecoder {
     int length = byteBuffer.getInt();
     byte[] rawBytes = readRawBytes(length);
     align();
-    return new String(rawBytes, StandardCharsets.US_ASCII);
+    return new String(rawBytes, Charsets.US_ASCII);
   }
 
   @Override
@@ -107,7 +105,7 @@ public class Xdr implements XdrEncoder, XdrDecoder {
     assertAligned();
     byte[] rawBytes = readRawBytes(length);
     align();
-    return new String(rawBytes, StandardCharsets.US_ASCII);
+    return new String(rawBytes, Charsets.US_ASCII);
   }
 
   @Override
@@ -148,7 +146,7 @@ public class Xdr implements XdrEncoder, XdrDecoder {
     byte[] rawBytes = new byte[length];
     try {
       byteBuffer.get(rawBytes, 0, length);
-    } catch (BufferUnderflowException | IndexOutOfBoundsException e) {
+    } catch (Exception e) {
       throw new DataOutOfBoundException(e);
     }
     return rawBytes;
@@ -178,7 +176,7 @@ public class Xdr implements XdrEncoder, XdrDecoder {
 
   @Override
   public void writeString(String string) throws XdrException {
-    byte[] rawBytes = string.getBytes(StandardCharsets.US_ASCII);
+    byte[] rawBytes = string.getBytes(Charsets.US_ASCII);
     if (rawBytes.length != string.length()) {
       throw new IllegalAsciiString();
     }
@@ -193,7 +191,7 @@ public class Xdr implements XdrEncoder, XdrDecoder {
 
   @Override
   public void writeFixedLengthString(int length, String string) throws XdrException {
-    byte[] rawBytes = string.getBytes(StandardCharsets.US_ASCII);
+    byte[] rawBytes = string.getBytes(Charsets.US_ASCII);
     if (rawBytes.length != string.length()) {
       throw new IllegalAsciiString();
     }

--- a/src/test/java/com/spotify/crtauth/protocol/ResponseTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/ResponseTest.java
@@ -35,7 +35,7 @@ public class ResponseTest extends XdrSerializableTest<Response> {
   protected Response getInstance() throws Exception {
     Challenge challenge = ChallengeTest.getDefaultChallenge();
     VerifiableMessage<Challenge> verifiableChallenge =
-        new VerifiableMessage.Builder<>(Challenge.class)
+        new VerifiableMessage.Builder<Challenge>(Challenge.class)
             .setPayload(challenge)
             .setDigest(new MessageHashDigestAlgorithm().getDigest(challenge.serialize()))
             .build();

--- a/src/test/java/com/spotify/crtauth/protocol/VerifiableMessageTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/VerifiableMessageTest.java
@@ -71,7 +71,7 @@ public class VerifiableMessageTest extends XdrSerializableTest<VerifiableMessage
     Challenge challenge = ChallengeTest.getDefaultChallenge();
     byte[] digest = new MessageHashDigestAlgorithm().getDigest(challenge.serialize());
     VerifiableMessage<Challenge> verifiableMessage =
-        new VerifiableMessage.Builder<>(Challenge.class)
+        new VerifiableMessage.Builder<Challenge>(Challenge.class)
             .setDigest(digest)
             .setPayload(challenge)
             .build();


### PR DESCRIPTION
If this library is going to be generally useful, I think we should avoid java7 features, as many people are stuck
on legacy java versions. The changes aren't that terrible anywy. Applies on top of the string API pull request.
