### PR TITLE
Implement exception hierarchy.

### DIFF
--- a/src/main/java/com/spotify/crtauth/exceptions/CrtAuthException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/CrtAuthException.java
@@ -1,0 +1,19 @@
+package com.spotify.crtauth.exceptions;
+
+public class CrtAuthException extends Exception {
+  public CrtAuthException() {
+    super();
+  }
+
+  public CrtAuthException(String message) {
+    super(message);
+  }
+
+  public CrtAuthException(Throwable throwable) {
+    super(throwable);
+  }
+
+  public CrtAuthException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/spotify/crtauth/exceptions/DataOutOfBoundException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/DataOutOfBoundException.java
@@ -21,8 +21,12 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class DataOutOfBoundException extends Exception {
+public class DataOutOfBoundException extends XdrException {
   public DataOutOfBoundException() {
     super();
+  }
+
+  public DataOutOfBoundException(Throwable cause) {
+    super(cause);
   }
 }

--- a/src/main/java/com/spotify/crtauth/exceptions/DeserializationException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/DeserializationException.java
@@ -21,8 +21,16 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class DeserializationException extends Exception {
-  public DeserializationException() {
-    super();
+public class DeserializationException extends CrtAuthException {
+  public DeserializationException(String message) {
+    super(message);
+  }
+
+  public DeserializationException(Throwable cause) {
+    super(cause);
+  }
+
+  public DeserializationException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/src/main/java/com/spotify/crtauth/exceptions/IllegalAsciiString.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/IllegalAsciiString.java
@@ -21,7 +21,7 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class IllegalAsciiString extends Exception {
+public class IllegalAsciiString extends XdrException {
   public IllegalAsciiString() {
     super();
   }

--- a/src/main/java/com/spotify/crtauth/exceptions/IllegalLengthException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/IllegalLengthException.java
@@ -21,7 +21,7 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class IllegalLengthException extends Exception {
+public class IllegalLengthException extends XdrException {
   public IllegalLengthException() {
     super();
   }

--- a/src/main/java/com/spotify/crtauth/exceptions/InvalidInputException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/InvalidInputException.java
@@ -21,7 +21,7 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class InvalidInputException extends Exception {
+public class InvalidInputException extends CrtAuthException {
   public InvalidInputException() {
     super();
   }

--- a/src/main/java/com/spotify/crtauth/exceptions/KeyNotFoundException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/KeyNotFoundException.java
@@ -21,7 +21,7 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class KeyNotFoundException extends Exception {
+public class KeyNotFoundException extends CrtAuthException {
   public KeyNotFoundException() {
     super();
   }

--- a/src/main/java/com/spotify/crtauth/exceptions/SerializationException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/SerializationException.java
@@ -21,8 +21,12 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class SerializationException extends Exception {
+public class SerializationException extends CrtAuthException {
   public SerializationException() {
     super();
+  }
+
+  public SerializationException(Throwable cause) {
+    super(cause);
   }
 }

--- a/src/main/java/com/spotify/crtauth/exceptions/SignerException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/SignerException.java
@@ -21,7 +21,7 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class SignerException extends Exception {
+public class SignerException extends CrtAuthException {
   public SignerException() {
     super();
   }

--- a/src/main/java/com/spotify/crtauth/exceptions/TokenExpiredException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/TokenExpiredException.java
@@ -21,7 +21,7 @@
 
 package com.spotify.crtauth.exceptions;
 
-public class TokenExpiredException extends Exception {
+public class TokenExpiredException extends CrtAuthException {
   public TokenExpiredException() {
     super();
   }

--- a/src/main/java/com/spotify/crtauth/exceptions/XdrException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/XdrException.java
@@ -1,0 +1,11 @@
+package com.spotify.crtauth.exceptions;
+
+public class XdrException extends Exception {
+  public XdrException() {
+    super();
+  }
+
+  public XdrException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/com/spotify/crtauth/protocol/Challenge.java
+++ b/src/main/java/com/spotify/crtauth/protocol/Challenge.java
@@ -24,6 +24,7 @@ package com.spotify.crtauth.protocol;
 import com.google.common.primitives.UnsignedInteger;
 import com.spotify.crtauth.exceptions.DeserializationException;
 import com.spotify.crtauth.exceptions.SerializationException;
+import com.spotify.crtauth.exceptions.XdrException;
 import com.spotify.crtauth.utils.TimeIntervals;
 import com.spotify.crtauth.utils.TimeSupplier;
 import com.spotify.crtauth.xdr.Xdr;
@@ -144,8 +145,8 @@ public class Challenge implements XdrSerializable {
       encoder.writeString(serverName);
       encoder.writeString(userName);
       return encoder.encode();
-    } catch (IOException e) {
-      throw new SerializationException();
+    } catch (XdrException e) {
+      throw new SerializationException(e);
     }
   }
 
@@ -156,7 +157,7 @@ public class Challenge implements XdrSerializable {
     try {
       String magic = decoder.readFixedLengthString(1);
       if (!magic.equals(MAGIC)) {
-        throw new DeserializationException();
+        throw new DeserializationException("invalid magic byte");
       }
       challenge.uniqueData = decoder.readFixedLengthOpaque(UNIQUE_DATA_LENGTH);
       challenge.validFromTimestamp = decoder.readInt();
@@ -164,8 +165,8 @@ public class Challenge implements XdrSerializable {
       challenge.figerprint = decoder.readVariableLengthOpaque();
       challenge.serverName = decoder.readString();
       challenge.userName = decoder.readString();
-    } catch(IOException e) {
-      throw new DeserializationException();
+    } catch (final XdrException e) {
+      throw new DeserializationException(e);
     }
     return challenge;
   }

--- a/src/main/java/com/spotify/crtauth/protocol/Response.java
+++ b/src/main/java/com/spotify/crtauth/protocol/Response.java
@@ -21,17 +21,17 @@
 
 package com.spotify.crtauth.protocol;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+
 import com.spotify.crtauth.exceptions.DeserializationException;
 import com.spotify.crtauth.exceptions.SerializationException;
+import com.spotify.crtauth.exceptions.XdrException;
 import com.spotify.crtauth.xdr.Xdr;
 import com.spotify.crtauth.xdr.XdrDecoder;
 import com.spotify.crtauth.xdr.XdrEncoder;
-
-import java.io.IOException;
-import java.util.Arrays;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Response implements XdrSerializable {
   private static final String MAGIC = "r";
@@ -76,8 +76,8 @@ public class Response implements XdrSerializable {
       encoder.writeVariableLengthOpaque(signature);
       encoder.writeVariableLengthOpaque(verifiableChallenge.serialize());
       return encoder.encode();
-    } catch (IOException e) {
-      throw new SerializationException();
+    } catch (XdrException e) {
+      throw new SerializationException(e);
     }
   }
 
@@ -94,8 +94,8 @@ public class Response implements XdrSerializable {
       byte[] verifiableMessageBytes = decoder.readVariableLengthOpaque();
       response.verifiableChallenge = verifiableMessageDecoder.deserialize(verifiableMessageBytes);
       return response;
-    } catch (IOException e) {
-      throw new DeserializationException();
+    } catch (XdrException e) {
+      throw new DeserializationException(e);
 
     }
   }

--- a/src/main/java/com/spotify/crtauth/protocol/Token.java
+++ b/src/main/java/com/spotify/crtauth/protocol/Token.java
@@ -21,19 +21,18 @@
 
 package com.spotify.crtauth.protocol;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.primitives.UnsignedInteger;
 import com.spotify.crtauth.exceptions.DeserializationException;
 import com.spotify.crtauth.exceptions.SerializationException;
+import com.spotify.crtauth.exceptions.XdrException;
 import com.spotify.crtauth.utils.TimeIntervals;
 import com.spotify.crtauth.utils.TimeSupplier;
 import com.spotify.crtauth.xdr.Xdr;
 import com.spotify.crtauth.xdr.XdrDecoder;
 import com.spotify.crtauth.xdr.XdrEncoder;
-
-import java.io.IOException;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Token implements XdrSerializable {
   private static final String MAGIC = "t";
@@ -109,8 +108,8 @@ public class Token implements XdrSerializable {
       encoder.writeInt(validTo);
       encoder.writeString(userName);
       return encoder.encode();
-    } catch (IOException e) {
-      throw new SerializationException();
+    } catch (XdrException e) {
+      throw new SerializationException(e);
     }
   }
 
@@ -125,8 +124,8 @@ public class Token implements XdrSerializable {
       token.validTo = decoder.readInt();
       token.userName = decoder.readString();
       return token;
-    } catch (IOException e) {
-      throw new DeserializationException();
+    } catch (XdrException e) {
+      throw new DeserializationException(e);
     }
   }
 

--- a/src/main/java/com/spotify/crtauth/xdr/XdrDecoder.java
+++ b/src/main/java/com/spotify/crtauth/xdr/XdrDecoder.java
@@ -23,6 +23,8 @@ package com.spotify.crtauth.xdr;
 
 import java.io.IOException;
 
+import com.spotify.crtauth.exceptions.XdrException;
+
 /**
  * This interface represents a decoder of XDR-encoded binary blobs. It supports a subset of the
  * data types described in RFC 4506.
@@ -34,7 +36,7 @@ public interface XdrDecoder {
    * @throws IOException if anything goes wrong (for example, if trying to read data that doesn't
    *    represent a string or if trying to read data from a non-aligned buffer position).
    */
-  public String readString() throws IOException;
+  public String readString() throws XdrException;
   /**
    * Decode and return a fixed length string. This data type is not defined in RFC 4506,
    * so this method can be seen as a convenience method that reads a fix-length blob of opaque
@@ -43,7 +45,7 @@ public interface XdrDecoder {
    * @throws IOException if anything goes wrong (for example, if trying to read data that doesn't
    *    represent a string or if trying to read data from a non-aligned buffer position).
    */
-  public String readFixedLengthString(int length) throws IOException;
+  public String readFixedLengthString(int length) throws XdrException;
   /**
    * Decode and return a fixed length blob of opaque data. This data type is defined in RFC 4506,
    * Section 4.9.
@@ -51,7 +53,7 @@ public interface XdrDecoder {
    * @throws IOException if anything goes wrong (for example, if trying to read data that doesn't
    *    represent a string or if trying to read data from a non-aligned buffer position).
    */
-  public byte[] readFixedLengthOpaque(int length) throws IOException;
+  public byte[] readFixedLengthOpaque(int length) throws XdrException;
   /**
    * Decode and return a fixed length blob of opaque data. This data type is defined in RFC 4506,
    * Section 4.10.
@@ -59,12 +61,12 @@ public interface XdrDecoder {
    * @throws IOException if anything goes wrong (for example, if trying to read data that doesn't
    *    represent a string or if trying to read data from a non-aligned buffer position).
    */
-  public byte[] readVariableLengthOpaque() throws IOException;
+  public byte[] readVariableLengthOpaque() throws XdrException;
   /**
    * Decode and return an integer number. This data type is defined in RFC 4506, 4.1.
    * @return A 32-bit integer.
    * @throws IOException if anything goes wrong (for example, if trying to read data that doesn't
    *    represent a string or if trying to read data from a non-aligned buffer position).
    */
-  public int readInt() throws IOException;
+  public int readInt() throws XdrException;
 }

--- a/src/main/java/com/spotify/crtauth/xdr/XdrEncoder.java
+++ b/src/main/java/com/spotify/crtauth/xdr/XdrEncoder.java
@@ -23,6 +23,8 @@ package com.spotify.crtauth.xdr;
 
 import java.io.IOException;
 
+import com.spotify.crtauth.exceptions.XdrException;
+
 /**
  * This interface represents an XDR encoder. It supports a subset of the data types described in
  * RFC 4506. The XDR Encoder encodes data sequentially, and return a binary representation of the
@@ -34,7 +36,8 @@ public interface XdrEncoder {
    * @param string The string data.
    * @throws IOException If anything goes wrong.
    */
-  public void writeString(String string) throws IOException;
+  public void writeString(String string) throws XdrException;
+
   /**
    * Encode a fixed length string. This data type is not defined in RFC 4506,
    * so this method can be seen as a convenience method that transforms a String into a
@@ -45,7 +48,9 @@ public interface XdrEncoder {
    * @param string The string data.
    * @throws IOException If anything goes wrong.
    */
-  public void writeFixedLengthString(int length, String string) throws IOException;
+  public void writeFixedLengthString(int length, String string)
+      throws XdrException;
+
   /**
    * Encode a fixed length blob of binary data. This data type is defined in RFC 4506,
    * Section 4.9.
@@ -55,24 +60,28 @@ public interface XdrEncoder {
    * @param bytes A byte blob.
    * @throws IOException If anything goes wrong.
    */
-  public void writeFixedLengthOpaque(int length, byte[] bytes) throws IOException;
+  public void writeFixedLengthOpaque(int length, byte[] bytes)
+      throws XdrException;
+
   /**
    * Encode a variable length blob of opaque data. This data type is defined in RFC 4506,
    * Section 4.10.
    * @param bytes A byte blob.
    * @throws IOException If anything goes wrong.
    */
-  public void writeVariableLengthOpaque(byte[] bytes) throws IOException;
+  public void writeVariableLengthOpaque(byte[] bytes) throws XdrException;
+
   /**
    * Encode an integer number. This data type is defined in RFC 4506, 4.1.
    * @param integer A 32-bit integer.
    * @throws IOException If anything goes wrong.
    */
-  public void writeInt(int integer) throws IOException;
+  public void writeInt(int integer) throws XdrException;
+
   /**
    * Return a serialized representation of whatever has been written to the {@code XdrEncoder}.
    * @return The RFC 4506-compliant representation of the XdrEncoder content, as a byte array.
    * @throws IOException If anything goes wrong.
    */
-  public byte[] encode() throws IOException;
+  public byte[] encode() throws XdrException;
 }


### PR DESCRIPTION
This change introduces two base exceptions.

`XdrException`, which acts as a base for all problems related to xdr encoding/decoding.
`CrtAuthException`, which acts as a base for all problems related to operation of the `CrtAuthClient/Server`.
