### PR TITLE
Use proper HMAC-SHA1 for message authentication

### DIFF
--- a/src/main/java/com/spotify/crtauth/digest/VerifiableDigestAlgorithm.java
+++ b/src/main/java/com/spotify/crtauth/digest/VerifiableDigestAlgorithm.java
@@ -21,26 +21,26 @@
 
 package com.spotify.crtauth.digest;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
+/**
+ * A DigestAlgorithm implementing HMAC using SHA1 as digest algorithm as specified by RFC2104.
+ */
 public class VerifiableDigestAlgorithm implements DigestAlgorithm {
-  private static final String DIGEST_ALGORITHM = "SHA-1";
-  private final byte[] secret;
+  private static final String MAC_ALGORITHM = "HmacSHA1";
+  private final SecretKeySpec secret;
 
   public VerifiableDigestAlgorithm(byte[] secret) {
-    this.secret = Arrays.copyOf(secret, secret.length);
+    this.secret = new SecretKeySpec(secret, MAC_ALGORITHM);
   }
 
   public byte[] getDigest(byte[] data) {
     try {
-      MessageDigest digest = MessageDigest.getInstance(DIGEST_ALGORITHM);
-      digest.reset();
-      digest.update(secret);
-      digest.update(data);
-      return Arrays.copyOf(digest.digest(), DIGEST_LENGTH);
-    } catch (NoSuchAlgorithmException e) {
+      Mac mac = Mac.getInstance(MAC_ALGORITHM);
+      mac.init(secret);
+      return mac.doFinal(data);
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }

--- a/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
+++ b/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
@@ -26,6 +26,7 @@ import com.spotify.crtauth.exceptions.InvalidInputException;
 import com.spotify.crtauth.keyprovider.InMemoryKeyProvider;
 import com.spotify.crtauth.protocol.Challenge;
 import com.spotify.crtauth.protocol.Response;
+import com.spotify.crtauth.protocol.Token;
 import com.spotify.crtauth.protocol.VerifiableMessage;
 import com.spotify.crtauth.signer.Signer;
 import com.spotify.crtauth.signer.SingleKeySigner;
@@ -134,5 +135,18 @@ public class CrtAuthServerTest {
     VerifiableMessage<Challenge> verifiableChallenge = crtAuthServer.createChallenge("test");
     Response response = crtAuthClient.createResponse(verifiableChallenge);
     otherOuthServer.createToken(response);
+  }
+
+  @Test(expected = InvalidInputException.class)
+  public void testWrongSecret() throws Exception {
+    CrtAuthServer otherServer = new CrtAuthServer.Builder()
+        .setServerName("SERVER_NAME")
+        .setSecret("another_secret".getBytes())
+        .setKeyProvider(keyProvider)
+        .build();
+    VerifiableMessage<Challenge> verifiableChallenge = crtAuthServer.createChallenge("test");
+    Response response = crtAuthClient.createResponse(verifiableChallenge);
+    VerifiableMessage<Token> token = crtAuthServer.createToken(response);
+    otherServer.validateToken(token);
   }
 }


### PR DESCRIPTION
- Test case to verify that the server secret indeed need to mach for
  tokens to be valid.
- Previously message authentication was done concatenating secret
  and payload feeding everything to SHA1, let's use HMAC-SHA1 as available
  in javax.security instead, heeding the advice of gkreitz.
