### PR TITLE
fix bug in token deserialization

### DIFF
--- a/src/main/java/com/spotify/crtauth/CrtAuthServer.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthServer.java
@@ -205,7 +205,7 @@ public class CrtAuthServer {
       throw new RuntimeException(e);
     }
     VerifiableMessage<Challenge> verifiableChallenge =
-        new VerifiableMessage.Builder<Challenge>(Challenge.class)
+        new VerifiableMessage.Builder(Challenge.class)
             .setDigest(digest)
             .setPayload(challenge)
             .build();
@@ -265,7 +265,7 @@ public class CrtAuthServer {
     }
     UnsignedInteger validFrom = timeSupplier.getTime().minus(CLOCK_FUDGE);
     UnsignedInteger validTo = timeSupplier.getTime().plus(tokenLifetimeInS);
-    Token token = new Token.Builder()
+    Token token = Token.newBuilder()
         .setUserName(challenge.getUserName())
         .setValidFrom(validFrom)
         .setValidTo(validTo)
@@ -276,7 +276,7 @@ public class CrtAuthServer {
     } catch (SerializationException e) {
       throw new RuntimeException(e);
     }
-    VerifiableMessage<Token> verifiableToken = new VerifiableMessage.Builder<Token>(Token.class)
+    VerifiableMessage<Token> verifiableToken = new VerifiableMessage.Builder(Token.class)
         .setDigest(digestAlgorithm.getDigest(serializedToken))
         .setPayload(token)
         .build();

--- a/src/main/java/com/spotify/crtauth/protocol/Token.java
+++ b/src/main/java/com/spotify/crtauth/protocol/Token.java
@@ -76,6 +76,12 @@ public class Token implements XdrSerializable {
     }
   }
 
+  public Token() {}
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
   public boolean isExpired(TimeSupplier timeSupplier) {
     return TimeIntervals.isExpired(validFrom, validTo, timeSupplier);
   }

--- a/src/test/java/com/spotify/crtauth/protocol/ChallengeTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/ChallengeTest.java
@@ -61,8 +61,6 @@ public class ChallengeTest extends XdrSerializableTest<Challenge> {
     assertArrayEquals(challenge.serialize(), encoding.decode(expected));
   }
 
-
-
   @Override
   protected Challenge getInstance() {
     return getDefaultChallenge();

--- a/src/test/java/com/spotify/crtauth/protocol/TokenTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/TokenTest.java
@@ -35,6 +35,14 @@ public class TokenTest extends XdrSerializableTest<Token> {
   private static final int DEFAULT_VALID_FROM = 10;
   private static final int DEFAULT_VALID_TO = 20;
 
+  public static Token getDefaultToken() {
+    return Token.newBuilder()
+        .setUserName("spotify")
+        .setValidFrom(DEFAULT_VALID_FROM)
+        .setValidTo(DEFAULT_VALID_TO)
+        .build();
+  }
+
   @Override
   protected Token getInstance() {
     return getDefaultToken();
@@ -85,11 +93,4 @@ public class TokenTest extends XdrSerializableTest<Token> {
     assertTrue(token.isExpired(timeSupplier));
   }
 
-  private Token getDefaultToken() {
-    return new Token.Builder()
-        .setUserName("spotify")
-        .setValidFrom(DEFAULT_VALID_FROM)
-        .setValidTo(DEFAULT_VALID_TO)
-        .build();
-  }
 }

--- a/src/test/java/com/spotify/crtauth/protocol/VerifiableMessageTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/VerifiableMessageTest.java
@@ -33,21 +33,29 @@ public class VerifiableMessageTest extends XdrSerializableTest<VerifiableMessage
 
   @Override
   protected VerifiableMessage getInstance() throws Exception {
-    return getDefaultVerifiableMessage();
+    return getVerifiableMessageChallenge();
   }
 
   @Test
-  public void testDeserializePayload() throws Exception {
-    VerifiableMessage<Challenge> verifiableMessage = getDefaultVerifiableMessage();
+  public void testDeserializePayloadChallenge() throws Exception {
+    VerifiableMessage<Challenge> verifiableMessage = getVerifiableMessageChallenge();
     byte[] data = verifiableMessage.serialize();
     VerifiableMessage<Challenge> deserialized = verifiableMessage.deserialize(data);
-    assertEquals(deserialized.getPayload(), getDefaultVerifiableMessage().getPayload());
+    assertEquals(deserialized.getPayload(), getVerifiableMessageChallenge().getPayload());
+  }
+
+  @Test
+  public void testDeserializePayloadToken() throws Exception {
+    VerifiableMessage<Token> verifiableMessage = getVerifiableMessageToken();
+    byte[] data = verifiableMessage.serialize();
+    VerifiableMessage<Token> deserialized = verifiableMessage.deserialize(data);
+    assertEquals(deserialized.getPayload(), getVerifiableMessageToken().getPayload());
   }
 
   @Test
   public void testVerifyMessage() throws Exception {
     DigestAlgorithm digestAlgorithm = new MessageHashDigestAlgorithm();
-    VerifiableMessage<Challenge> verifiableMessage = getDefaultVerifiableMessage();
+    VerifiableMessage<Challenge> verifiableMessage = getVerifiableMessageChallenge();
     assertTrue(verifiableMessage.verify(digestAlgorithm));
     byte[] data = verifiableMessage.serialize();
     VerifiableMessage<Challenge> deserialized = verifiableMessage.deserialize(data);
@@ -57,7 +65,7 @@ public class VerifiableMessageTest extends XdrSerializableTest<VerifiableMessage
   @Test
   public void testVerifyCorruptMessage() throws Exception {
     DigestAlgorithm digestAlgorithm = new MessageHashDigestAlgorithm();
-    VerifiableMessage<Challenge> verifiableMessage = getDefaultVerifiableMessage();
+    VerifiableMessage<Challenge> verifiableMessage = getVerifiableMessageChallenge();
     assertTrue(verifiableMessage.verify(digestAlgorithm));
     byte[] data = verifiableMessage.serialize();
     // Alter the message but make sure it's still parsable
@@ -67,13 +75,24 @@ public class VerifiableMessageTest extends XdrSerializableTest<VerifiableMessage
     assertFalse(deserialized.verify(digestAlgorithm));
   }
 
-  private VerifiableMessage<Challenge> getDefaultVerifiableMessage() throws Exception {
+  private VerifiableMessage<Challenge> getVerifiableMessageChallenge() throws Exception {
     Challenge challenge = ChallengeTest.getDefaultChallenge();
     byte[] digest = new MessageHashDigestAlgorithm().getDigest(challenge.serialize());
     VerifiableMessage<Challenge> verifiableMessage =
         new VerifiableMessage.Builder<Challenge>(Challenge.class)
             .setDigest(digest)
             .setPayload(challenge)
+            .build();
+    return verifiableMessage;
+  }
+
+  private VerifiableMessage<Token> getVerifiableMessageToken() throws Exception {
+    Token token = TokenTest.getDefaultToken();
+    byte[] digest = new MessageHashDigestAlgorithm().getDigest(token.serialize());
+    VerifiableMessage<Token> verifiableMessage =
+        new VerifiableMessage.Builder<Token>(Token.class)
+            .setDigest(digest)
+            .setPayload(token)
             .build();
     return verifiableMessage;
   }


### PR DESCRIPTION
- clean up code a bit

The following code failed before my fix:

```
byte[] serialized = TEST_TOKEN_MSG.serialize();
VerifiableMessage<Token> r = VerifiableMessage.getDefaultInstance(Token.class).deserialize(serialized);
assertEquals(TEST_TOKEN_MSG.getPayload().getUserName(), r.getPayload().getUserName());
```
