### PR TITLE
Signer.sign() now throws KeyNotFoundException

### DIFF
--- a/src/main/java/com/spotify/crtauth/CrtAuthClient.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthClient.java
@@ -23,6 +23,7 @@ package com.spotify.crtauth;
 
 import com.spotify.crtauth.exceptions.DeserializationException;
 import com.spotify.crtauth.exceptions.InvalidInputException;
+import com.spotify.crtauth.exceptions.KeyNotFoundException;
 import com.spotify.crtauth.exceptions.SerializationException;
 import com.spotify.crtauth.exceptions.SignerException;
 import com.spotify.crtauth.protocol.Challenge;
@@ -64,7 +65,7 @@ public class CrtAuthClient {
    * @throws SignerException If a valid signature for the input challenge cannot be produced.
    */
   public String createResponse(String challenge)
-      throws InvalidInputException, SignerException {
+      throws InvalidInputException, SignerException, KeyNotFoundException {
     byte[] decodedChallenge = decode(challenge);
     Challenge deserializedChallenge;
     try {

--- a/src/main/java/com/spotify/crtauth/signer/Signer.java
+++ b/src/main/java/com/spotify/crtauth/signer/Signer.java
@@ -22,6 +22,7 @@
 package com.spotify.crtauth.signer;
 
 import com.spotify.crtauth.Fingerprint;
+import com.spotify.crtauth.exceptions.KeyNotFoundException;
 import com.spotify.crtauth.exceptions.SignerException;
 
 /**
@@ -36,8 +37,9 @@ public interface Signer {
    *
    * @param data Some data to sign, typically a serialized challenge
    * @return A signature, as a byte array.
-   * @throws SignerException If the signer can't produce a valid signature (for example if the
-   *    challenge can't be serialized).
+   * @throws SignerException If the signer can't produce a valid signature.
+   *
    */
-  public byte[] sign(byte[] data, Fingerprint fingerprint) throws SignerException;
+  public byte[] sign(byte[] data, Fingerprint fingerprint)
+      throws SignerException, KeyNotFoundException;
 }


### PR DESCRIPTION
It seems reasonable that signers can throw KeyNotFoundException (because sometimes the key is not found)
