### PR TITLE
createChallenge now takes request message instead of bare username

### DIFF
--- a/src/main/java/com/spotify/crtauth/CrtAuthClient.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthClient.java
@@ -83,4 +83,15 @@ public class CrtAuthClient {
       throw new InvalidInputException(e);
     }
   }
+
+  /**
+   * Create a request string from a username. Request is too trivial for it to make it into a
+   * class of it's own a this stage.
+   *
+   * @param username the username to encode
+   * @return an encoded request message
+   */
+  public static String createRequest(String username) {
+    return CrtAuthCodec.serializeEncodedRequest(username);
+  }
 }

--- a/src/main/java/com/spotify/crtauth/CrtAuthServer.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthServer.java
@@ -170,12 +170,19 @@ public class CrtAuthServer {
    * the public key, a fake Fingerprint is generated so that the presence of a challenge doesn't
    * reveal whether a user key is present on the server or not.
    *
-   * @param userName The username of the user to be authenticated, in the format required by
-   *    KeyProvider instances
+   * @param request The request message which contains an encoded username
    *
    * @return A challenge message.
    */
-  public String createChallenge(String userName) {
+  public String createChallenge(String request) throws InvalidInputException {
+
+    String userName = null;
+    try {
+      userName = CrtAuthCodec.deserializeRequest(request);
+    } catch (DeserializationException e) {
+      throw new InvalidInputException(e);
+    }
+
     Fingerprint fingerprint;
     try {
       fingerprint = new Fingerprint(keyProvider.getKey(userName));

--- a/src/test/java/com/spotify/crtauth/CrtAuthClientTest.java
+++ b/src/test/java/com/spotify/crtauth/CrtAuthClientTest.java
@@ -29,14 +29,14 @@ import com.spotify.crtauth.utils.TraditionalKeyParser;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPrivateKeySpec;
 import java.security.spec.RSAPublicKeySpec;
+
+import static org.junit.Assert.assertEquals;
 
 public class CrtAuthClientTest {
   private static final String SERVER_NAME = "server_name";
@@ -117,7 +117,7 @@ public class CrtAuthClientTest {
 
   @Test
   public void testValidResponse() throws Exception {
-    String challenge = crtAuthServer.createChallenge("test");
+    String challenge = crtAuthServer.createChallenge(CrtAuthClient.createRequest("test"));
     CrtAuthClient crtAuthClient = new CrtAuthClient(signer, SERVER_NAME);
     String response = crtAuthClient.createResponse(challenge);
     String verifiableToken = crtAuthServer.createToken(response);
@@ -126,8 +126,13 @@ public class CrtAuthClientTest {
 
   @Test(expected = InvalidInputException.class)
   public void testMitm() throws Exception {
-    String verifiableChallenge = crtAuthServer.createChallenge("test");
+    String verifiableChallenge = crtAuthServer.createChallenge(CrtAuthClient.createRequest("test"));
     CrtAuthClient crtAuthClient = new CrtAuthClient(signer, "another_server");
     crtAuthClient.createResponse(verifiableChallenge);
+  }
+
+  @Test
+  public void testCreateRequest() throws Exception {
+    assertEquals("AXGjbm9h", CrtAuthClient.createRequest("noa"));
   }
 }

--- a/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
+++ b/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
@@ -115,7 +115,7 @@ public class CrtAuthServerTest {
         .setSecret(serverSecret)
         .setKeyProvider(keyProvider)
         .build();
-    String challenge = crtAuthServer.createChallenge("noa");
+    String challenge = crtAuthServer.createChallenge(CrtAuthClient.createRequest("noa"));
     Fingerprint expectedFingerprint = new Fingerprint(decode("-6Hqb9N5"));
     Assert.assertTrue(extractFingerprint(challenge).equals(expectedFingerprint));
   }
@@ -128,7 +128,7 @@ public class CrtAuthServerTest {
         .setSecret(serverSecret)
         .setKeyProvider(keyProvider)
         .build();
-    String encodedChallenge = crtAuthServer.createChallenge("another");
+    String encodedChallenge = crtAuthServer.createChallenge(CrtAuthClient.createRequest("another"));
     // just make sure that we have a parsable challenge
     CrtAuthCodec.deserializeChallenge(ASCIICodec.decode(encodedChallenge));
   }
@@ -144,7 +144,7 @@ public class CrtAuthServerTest {
         .setSecret("server_secret".getBytes())
         .setKeyProvider(keyProvider)
         .build();
-    String verifiableChallenge = crtAuthServer.createChallenge("test");
+    String verifiableChallenge = crtAuthServer.createChallenge(CrtAuthClient.createRequest("test"));
     String response = crtAuthClient.createResponse(verifiableChallenge);
     otherOuthServer.createToken(response);
   }
@@ -156,7 +156,7 @@ public class CrtAuthServerTest {
         .setSecret("another_secret".getBytes())
         .setKeyProvider(keyProvider)
         .build();
-    String verifiableChallenge = crtAuthServer.createChallenge("test");
+    String verifiableChallenge = crtAuthServer.createChallenge(CrtAuthClient.createRequest("test"));
     String response = crtAuthClient.createResponse(verifiableChallenge);
     otherServer.validateToken(crtAuthServer.createToken(response));
   }

--- a/src/test/java/com/spotify/crtauth/protocol/CrtAuthCodecTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/CrtAuthCodecTest.java
@@ -18,6 +18,7 @@ package com.spotify.crtauth.protocol;
 
 import com.google.common.primitives.UnsignedInteger;
 import com.spotify.crtauth.ASCIICodec;
+import com.spotify.crtauth.CrtAuthClient;
 import com.spotify.crtauth.CrtAuthClientTest;
 import com.spotify.crtauth.Fingerprint;
 import com.spotify.crtauth.exceptions.DeserializationException;
@@ -28,6 +29,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests CrtAuthCodec
@@ -76,7 +79,7 @@ public class CrtAuthCodecTest {
     Challenge challenge = CrtAuthCodec.deserializeChallengeAuthenticated(
         ENCODED_CHALLENGE, "secret".getBytes());
 
-    Assert.assertEquals(CHALLENGE, challenge);
+    assertEquals(CHALLENGE, challenge);
   }
 
   @Test
@@ -98,7 +101,7 @@ public class CrtAuthCodecTest {
     Signer signer = new SingleKeySigner(CrtAuthClientTest.getPrivateKey());
     byte[] signature = signer.sign(r.getPayload(), c.getFingerprint());
     Assert.assertArrayEquals(signature, r.getSignature());
-    Assert.assertEquals(c, CHALLENGE);
+    assertEquals(c, CHALLENGE);
   }
 
   @Test
@@ -109,7 +112,7 @@ public class CrtAuthCodecTest {
   @Test
   public void testDeserializeToken() throws Exception {
     Token token = CrtAuthCodec.deserializeToken(ENCODED_TOKEN);
-    Assert.assertEquals(TOKEN, token);
+    assertEquals(TOKEN, token);
   }
 
   @Test(expected = InvalidInputException.class)
@@ -133,5 +136,10 @@ public class CrtAuthCodecTest {
     return CrtAuthCodec.deserializeChallenge(challenge).getFingerprint();
   }
 
+
+  @Test
+  public void testDeserializeRequest() throws Exception {
+    assertEquals("noa", CrtAuthCodec.deserializeRequest("AXGjbm9h"));
+  }
 
 }


### PR DESCRIPTION
This to implement updated spec, handle non-ascii usernames and to embed
version information in the initial request.
