### PR TITLE
Fix license boilerplate in .java file headers

### DIFF
--- a/java.header
+++ b/java.header
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/CrtAuthClient.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthClient.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/CrtAuthServer.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthServer.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/Fingerprint.java
+++ b/src/main/java/com/spotify/crtauth/Fingerprint.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/exceptions/CrtAuthException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/CrtAuthException.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/exceptions/KeyNotFoundException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/KeyNotFoundException.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/exceptions/ProtocolVersionException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/ProtocolVersionException.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/exceptions/TokenExpiredException.java
+++ b/src/main/java/com/spotify/crtauth/exceptions/TokenExpiredException.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/keyprovider/FileKeyProvider.java
+++ b/src/main/java/com/spotify/crtauth/keyprovider/FileKeyProvider.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/keyprovider/InMemoryKeyProvider.java
+++ b/src/main/java/com/spotify/crtauth/keyprovider/InMemoryKeyProvider.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/keyprovider/KeyProvider.java
+++ b/src/main/java/com/spotify/crtauth/keyprovider/KeyProvider.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/protocol/Challenge.java
+++ b/src/main/java/com/spotify/crtauth/protocol/Challenge.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/protocol/CrtAuthCodec.java
+++ b/src/main/java/com/spotify/crtauth/protocol/CrtAuthCodec.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/protocol/DeserializationException.java
+++ b/src/main/java/com/spotify/crtauth/protocol/DeserializationException.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/protocol/MiniMessagePack.java
+++ b/src/main/java/com/spotify/crtauth/protocol/MiniMessagePack.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/protocol/Response.java
+++ b/src/main/java/com/spotify/crtauth/protocol/Response.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/protocol/Token.java
+++ b/src/main/java/com/spotify/crtauth/protocol/Token.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/signer/Signer.java
+++ b/src/main/java/com/spotify/crtauth/signer/Signer.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/signer/SingleKeySigner.java
+++ b/src/main/java/com/spotify/crtauth/signer/SingleKeySigner.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/utils/ASCIICodec.java
+++ b/src/main/java/com/spotify/crtauth/utils/ASCIICodec.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/utils/RealTimeSupplier.java
+++ b/src/main/java/com/spotify/crtauth/utils/RealTimeSupplier.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/utils/SettableTimeSupplier.java
+++ b/src/main/java/com/spotify/crtauth/utils/SettableTimeSupplier.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/utils/TimeIntervals.java
+++ b/src/main/java/com/spotify/crtauth/utils/TimeIntervals.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/utils/TimeSupplier.java
+++ b/src/main/java/com/spotify/crtauth/utils/TimeSupplier.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/spotify/crtauth/utils/TraditionalKeyParser.java
+++ b/src/main/java/com/spotify/crtauth/utils/TraditionalKeyParser.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/CrtAuthClientTest.java
+++ b/src/test/java/com/spotify/crtauth/CrtAuthClientTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
+++ b/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/FingerprintTest.java
+++ b/src/test/java/com/spotify/crtauth/FingerprintTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/protocol/ChallengeTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/ChallengeTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/protocol/CrtAuthCodecTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/CrtAuthCodecTest.java
@@ -1,17 +1,18 @@
 /*
- * Copyright (c) 2015 Spotify AB
+ * Copyright (c) 2015 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/license/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.spotify.crtauth.protocol;

--- a/src/test/java/com/spotify/crtauth/protocol/MiniMessagePackTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/MiniMessagePackTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -18,6 +14,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.spotify.crtauth.protocol;
 
 import org.junit.Assert;

--- a/src/test/java/com/spotify/crtauth/protocol/TokenTest.java
+++ b/src/test/java/com/spotify/crtauth/protocol/TokenTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/signer/SignerTest.java
+++ b/src/test/java/com/spotify/crtauth/signer/SignerTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/signer/SingleKeySignerTest.java
+++ b/src/test/java/com/spotify/crtauth/signer/SingleKeySignerTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/spotify/crtauth/utils/ASCIICodecTest.java
+++ b/src/test/java/com/spotify/crtauth/utils/ASCIICodecTest.java
@@ -1,17 +1,18 @@
 /*
- * Copyright (c) 2015 Spotify AB
+ * Copyright (c) 2015 Spotify AB.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/license/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package com.spotify.crtauth.utils;

--- a/src/test/java/com/spotify/crtauth/utils/TraditionalKeyParserTest.java
+++ b/src/test/java/com/spotify/crtauth/utils/TraditionalKeyParserTest.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2015 Spotify AB.
  *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *


### PR DESCRIPTION
It should not state "Licensed to the Apache Software
Foundation..."