### PR TITLE
Fix exception thrown by CrtAuthServer.Builder

### DIFF
--- a/src/main/java/com/spotify/crtauth/CrtAuthServer.java
+++ b/src/main/java/com/spotify/crtauth/CrtAuthServer.java
@@ -125,14 +125,14 @@ public class CrtAuthServer {
       return this;
     }
 
-    public CrtAuthServer build() throws TokenExpiredException {
+    public CrtAuthServer build() {
       checkNotNull(serverName);
       checkNotNull(keyProvider);
       checkNotNull(secret);
 
       final UnsignedInteger lifetime = tokenLifetimeSeconds.or(DEFAULT_TOKEN_LIFETIME_SECONDS);
       if (lifetime.intValue() > MAX_VALIDITY) {
-        throw new TokenExpiredException(String.format(
+        throw new IllegalArgumentException(String.format(
             "Overly long token lifetime. Max lifetime is %d.", MAX_VALIDITY));
       }
 

--- a/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
+++ b/src/test/java/com/spotify/crtauth/CrtAuthServerTest.java
@@ -193,7 +193,7 @@ public class CrtAuthServerTest {
     crtAuthServer.validateToken(ts);
   }
 
-  @Test(expected = TokenExpiredException.class)
+  @Test(expected = IllegalArgumentException.class)
   public void testBuilderFailsOnOverlyLongTokenValidity() throws Exception {
     new CrtAuthServer.Builder()
         .setServerName(SERVER_NAME)


### PR DESCRIPTION
When the supplied `tokenLifetimeSeconds` is too long, the builder should
throw an IllegalArgumentException, not a TokenExpiredException.